### PR TITLE
refine portfolio layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# PersonalWebsite
+# Personal Website Prototype
+
+This project contains a React-based single-page layout that mirrors the reference portfolio design provided.
+
+## Getting Started
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Start the development server:
+   ```bash
+   npm run dev
+   ```
+3. Open the printed local URL in your browser to view the site.
+
+## Building for Production
+
+```bash
+npm run build
+```
+
+The generated production assets will be available in the `dist` directory.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Deividas Ilgunas</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "personal-website",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "vite": "^4.4.9"
+  }
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,258 @@
+import profileImg from './assets/profile-placeholder.svg';
+import aboutImg from './assets/about-placeholder.svg';
+import projectImg from './assets/project-placeholder.svg';
+import galleryImg from './assets/gallery-placeholder.svg';
+
+const stats = [
+  { label: 'Years crafting interfaces', value: '8+' },
+  { label: 'Products shipped', value: '27' },
+  { label: 'Satisfied teams', value: '40+' },
+];
+
+const services = [
+  {
+    title: 'Product Strategy',
+    description:
+      'Collaborative workshops that define the north-star experience, uncover user needs, and map out the release roadmap.',
+  },
+  {
+    title: 'Experience Design',
+    description:
+      'Pixel-perfect interfaces with thoughtful motion, accessible patterns, and design systems ready for engineering.',
+  },
+  {
+    title: 'Front-end Engineering',
+    description:
+      'Production-ready React builds with robust component libraries, documentation, and performance baked in from the start.',
+  },
+];
+
+const caseStudies = [
+  {
+    title: 'Nova Health',
+    subtitle: 'Patient onboarding platform',
+    description:
+      'Reimagined the intake experience for a telehealth startup, increasing completed sessions by 34% in the first quarter.',
+    tags: ['UX Research', 'Design System', 'React Build'],
+    image: projectImg,
+  },
+  {
+    title: 'Orbit Finance',
+    subtitle: 'Investment analytics dashboard',
+    description:
+      'Crafted a modular analytics surface for financial teams to track performance, collaborate on insights, and act quickly.',
+    tags: ['Product Strategy', 'UI Design', 'Prototyping'],
+    image: projectImg,
+  },
+  {
+    title: 'Shift Mobility',
+    subtitle: 'EV charging network',
+    description:
+      'Built a responsive map-based experience that helps drivers locate charging stations, monitor sessions, and earn rewards.',
+    tags: ['Design Ops', 'Responsive Web', 'Brand'],
+    image: projectImg,
+  },
+];
+
+const galleryItems = [
+  { label: 'Design Summit, Vilnius', image: galleryImg },
+  { label: 'Client Workshop', image: galleryImg },
+  { label: 'Team Offsite', image: galleryImg },
+];
+
+const App = () => {
+  return (
+    <div className="page">
+      <header className="header">
+        <div className="header-surface" />
+        <nav className="nav">
+          <div className="brand">DI</div>
+          <div className="nav-links">
+            <a href="#about">About</a>
+            <a href="#projects">Projects</a>
+            <a href="#services">Services</a>
+            <a href="#contact">Contact</a>
+          </div>
+          <a className="nav-contact" href="mailto:hello@example.com">
+            Let&apos;s Talk
+          </a>
+        </nav>
+
+        <section className="hero" id="top">
+          <div className="hero-copy">
+            <p className="eyebrow">Product Designer &amp; Front-end Engineer</p>
+            <h1>
+              Deividas
+              <br />
+              Ilgunas
+            </h1>
+            <p className="lead">
+              Partnering with mission-led teams to transform complex problems into effortless digital experiences. From early
+              discovery to polished production, I bridge design and code to deliver measurable results.
+            </p>
+            <div className="hero-actions">
+              <a className="btn primary" href="#projects">
+                View Projects
+              </a>
+              <a className="btn ghost" href="#resume">
+                Download CV
+              </a>
+            </div>
+            <div className="hero-stats">
+              {stats.map((stat) => (
+                <div key={stat.label} className="stat-card">
+                  <span className="stat-value">{stat.value}</span>
+                  <span className="stat-label">{stat.label}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="hero-visual">
+            <div className="hero-card">
+              <img src={profileImg} alt="Portrait of Deividas Ilgunas" />
+              <div className="hero-card-body">
+                <div className="hero-card-header">
+                  <span className="hero-card-title">Currently crafting</span>
+                  <span className="hero-card-pill">In progress</span>
+                </div>
+                <h3>Fintech Dashboard Revamp</h3>
+                <p>
+                  Consolidating analytics, billing, and forecasting into a unified workspace with tailored role permissions.
+                </p>
+                <div className="progress">
+                  <div className="progress-bar" style={{ width: '72%' }} />
+                </div>
+                <div className="hero-card-meta">
+                  <span>UX Audit</span>
+                  <span>Delivery Q3</span>
+                </div>
+              </div>
+            </div>
+            <div className="hero-float hero-pill">Trusted by teams across EU &amp; US</div>
+            <div className="hero-float hero-availability">
+              <span>Next availability</span>
+              <strong>June 2024</strong>
+            </div>
+          </div>
+        </section>
+      </header>
+
+      <main>
+        <section id="about" className="section about">
+          <div className="section-heading">
+            <p className="eyebrow">About</p>
+            <h2>The intersection of storytelling, systems, and shipping</h2>
+          </div>
+          <div className="about-layout">
+            <img src={aboutImg} alt="Design process collage" />
+            <div className="about-copy">
+              <p>
+                Over the past eight years I&apos;ve helped founders, product teams, and agencies translate vision into interactive
+                journeys that customers trust. My approach combines qualitative research, rapid prototyping, and hands-on
+                engineering to move fast without sacrificing craft.
+              </p>
+              <ul className="about-highlights">
+                <li>
+                  <span className="highlight-title">Workshops</span>
+                  <span className="highlight-description">Facilitated design sprints with teams from Series A to Fortune 500.</span>
+                </li>
+                <li>
+                  <span className="highlight-title">Design Systems</span>
+                  <span className="highlight-description">Maintained component libraries powering 5+ product teams.</span>
+                </li>
+                <li>
+                  <span className="highlight-title">Performance</span>
+                  <span className="highlight-description">Ship responsive, accessible builds with Core Web Vitals in the green.</span>
+                </li>
+              </ul>
+            </div>
+          </div>
+        </section>
+
+        <section id="services" className="section services">
+          <div className="section-heading">
+            <p className="eyebrow">Services</p>
+            <h2>How I help teams scale their products</h2>
+          </div>
+          <div className="service-grid">
+            {services.map((service) => (
+              <article key={service.title} className="service-card">
+                <h3>{service.title}</h3>
+                <p>{service.description}</p>
+                <a className="learn-more" href="#contact">
+                  Let&apos;s collaborate
+                </a>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section id="projects" className="section projects">
+          <div className="section-heading">
+            <p className="eyebrow">Selected Work</p>
+            <h2>Case studies that blend clarity and momentum</h2>
+          </div>
+          <div className="case-grid">
+            {caseStudies.map((project) => (
+              <article key={project.title} className="case-card">
+                <img src={project.image} alt={project.subtitle} className="case-media" />
+                <div className="case-body">
+                  <div className="case-meta">
+                    <span className="case-title">{project.title}</span>
+                    <span className="case-subtitle">{project.subtitle}</span>
+                  </div>
+                  <p>{project.description}</p>
+                  <div className="tag-row">
+                    {project.tags.map((tag) => (
+                      <span key={tag} className="tag">
+                        {tag}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section className="section gallery">
+          <div className="section-heading">
+            <p className="eyebrow">Behind the scenes</p>
+            <h2>Snapshots from collaborations worldwide</h2>
+          </div>
+          <div className="gallery-grid">
+            {galleryItems.map((item) => (
+              <figure key={item.label} className="gallery-card">
+                <img src={item.image} alt={item.label} />
+                <figcaption>{item.label}</figcaption>
+              </figure>
+            ))}
+          </div>
+        </section>
+      </main>
+
+      <footer id="contact" className="contact">
+        <div className="contact-card">
+          <p className="eyebrow">Let&apos;s build together</p>
+          <h2>Have a project in mind?</h2>
+          <p>
+            I&apos;m currently booking collaborations for Q3. Share a little about your goals and we&apos;ll schedule a workshop to map the
+            path forward.
+          </p>
+          <div className="contact-actions">
+            <a className="btn primary" href="mailto:hello@example.com">
+              Start a conversation
+            </a>
+            <a className="btn ghost" href="https://cal.com" target="_blank" rel="noreferrer">
+              Schedule a call
+            </a>
+          </div>
+        </div>
+        <p className="footer-note">© {new Date().getFullYear()} Deividas Ilgunas. Crafted with purpose in Vilnius.</p>
+      </footer>
+    </div>
+  );
+};
+
+export default App;

--- a/src/assets/about-placeholder.svg
+++ b/src/assets/about-placeholder.svg
@@ -1,0 +1,10 @@
+<svg width="420" height="300" viewBox="0 0 420 300" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="gradAbout" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#c084fc" />
+      <stop offset="100%" stop-color="#a855f7" />
+    </linearGradient>
+  </defs>
+  <rect width="420" height="300" rx="28" fill="url(#gradAbout)" />
+  <text x="50%" y="50%" text-anchor="middle" dominant-baseline="middle" font-family="Poppins, sans-serif" font-size="28" fill="white">About Image</text>
+</svg>

--- a/src/assets/gallery-placeholder.svg
+++ b/src/assets/gallery-placeholder.svg
@@ -1,0 +1,10 @@
+<svg width="960" height="320" viewBox="0 0 960 320" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="gradGallery" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#c4b5fd" />
+      <stop offset="100%" stop-color="#818cf8" />
+    </linearGradient>
+  </defs>
+  <rect width="960" height="320" rx="36" fill="url(#gradGallery)" />
+  <text x="50%" y="50%" text-anchor="middle" dominant-baseline="middle" font-family="Poppins, sans-serif" font-size="48" fill="white">Gallery</text>
+</svg>

--- a/src/assets/profile-placeholder.svg
+++ b/src/assets/profile-placeholder.svg
@@ -1,0 +1,10 @@
+<svg width="320" height="320" viewBox="0 0 320 320" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#8b5cf6" />
+      <stop offset="100%" stop-color="#ec4899" />
+    </linearGradient>
+  </defs>
+  <rect width="320" height="320" rx="32" fill="url(#grad)" />
+  <text x="50%" y="50%" text-anchor="middle" dominant-baseline="middle" font-family="Poppins, sans-serif" font-size="32" fill="white">Profile</text>
+</svg>

--- a/src/assets/project-placeholder.svg
+++ b/src/assets/project-placeholder.svg
@@ -1,0 +1,10 @@
+<svg width="360" height="220" viewBox="0 0 360 220" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="gradProject" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#a855f7" />
+      <stop offset="100%" stop-color="#6366f1" />
+    </linearGradient>
+  </defs>
+  <rect width="360" height="220" rx="24" fill="url(#gradProject)" />
+  <text x="50%" y="50%" text-anchor="middle" dominant-baseline="middle" font-family="Poppins, sans-serif" font-size="24" fill="white">Project</text>
+</svg>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.jsx';
+import './styles.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,0 +1,644 @@
+:root {
+  --surface: #ffffff;
+  --ink: #0f172a;
+  --muted: #475569;
+  --accent: #6d28d9;
+  --accent-soft: #ede9fe;
+  --gradient-hero: radial-gradient(circle at top right, rgba(109, 40, 217, 0.35), transparent 55%),
+    radial-gradient(circle at 20% 20%, rgba(14, 165, 233, 0.25), transparent 55%),
+    linear-gradient(180deg, #f8f5ff 0%, #ffffff 80%);
+  font-family: 'Poppins', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  color: var(--ink);
+  background: var(--gradient-hero);
+  line-height: 1.6;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  background: transparent;
+}
+
+img {
+  display: block;
+  max-width: 100%;
+}
+
+.page {
+  position: relative;
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: 48px 24px 120px;
+}
+
+.header {
+  position: relative;
+  padding-bottom: 96px;
+}
+
+.header-surface {
+  position: absolute;
+  inset: 0;
+  border-radius: 48px;
+  background: rgba(255, 255, 255, 0.55);
+  backdrop-filter: blur(22px);
+  box-shadow: 0 40px 120px rgba(15, 23, 42, 0.12);
+  z-index: -1;
+}
+
+.nav {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 28px 40px 0;
+}
+
+.brand {
+  font-size: 20px;
+  font-weight: 700;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+}
+
+.nav-links {
+  display: flex;
+  gap: 28px;
+  font-size: 14px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.nav a {
+  color: inherit;
+  text-decoration: none;
+  opacity: 0.72;
+  transition: opacity 0.2s ease;
+}
+
+.nav a:hover {
+  opacity: 1;
+}
+
+.nav-contact {
+  padding: 10px 28px;
+  border-radius: 999px;
+  border: 1.5px solid rgba(109, 40, 217, 0.5);
+  color: var(--accent);
+  font-weight: 600;
+  text-decoration: none;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr);
+  gap: 64px;
+  padding: 72px 80px 0 80px;
+}
+
+.hero-copy h1 {
+  font-size: clamp(56px, 7vw, 120px);
+  line-height: 0.9;
+  text-transform: uppercase;
+  margin-bottom: 32px;
+}
+
+.eyebrow {
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+.lead {
+  font-size: 18px;
+  color: var(--muted);
+  margin-bottom: 32px;
+  max-width: 520px;
+}
+
+.hero-actions {
+  display: flex;
+  gap: 16px;
+  margin-bottom: 48px;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 14px 32px;
+  border-radius: 999px;
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.btn.primary {
+  background: linear-gradient(120deg, #7c3aed, #6366f1);
+  color: white;
+  box-shadow: 0 20px 40px rgba(99, 102, 241, 0.3);
+}
+
+.btn.ghost {
+  color: var(--accent);
+  border: 1.5px solid rgba(109, 40, 217, 0.35);
+  background: rgba(255, 255, 255, 0.7);
+}
+
+.btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 24px 48px rgba(109, 40, 217, 0.25);
+}
+
+.hero-stats {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.stat-card {
+  padding: 20px 24px;
+  border-radius: 24px;
+  background: rgba(255, 255, 255, 0.75);
+  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.stat-value {
+  font-size: 28px;
+  font-weight: 600;
+}
+
+.stat-label {
+  font-size: 13px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.hero-visual {
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.hero-card {
+  position: relative;
+  border-radius: 36px;
+  overflow: hidden;
+  background: rgba(15, 23, 42, 0.92);
+  color: white;
+  box-shadow: 0 40px 80px rgba(15, 23, 42, 0.35);
+  width: min(420px, 100%);
+}
+
+.hero-card img {
+  width: 100%;
+  height: 280px;
+  object-fit: cover;
+}
+
+.hero-card-body {
+  padding: 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.hero-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.hero-card-title {
+  font-size: 13px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  opacity: 0.7;
+}
+
+.hero-card-pill {
+  padding: 6px 16px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.1);
+  font-size: 12px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.hero-card h3 {
+  font-size: 24px;
+  line-height: 1.2;
+}
+
+.hero-card p {
+  font-size: 16px;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.progress {
+  width: 100%;
+  height: 6px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.16);
+  overflow: hidden;
+}
+
+.progress-bar {
+  height: 100%;
+  background: linear-gradient(90deg, #22d3ee, #7c3aed);
+  border-radius: inherit;
+}
+
+.hero-card-meta {
+  display: flex;
+  justify-content: space-between;
+  font-size: 12px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  opacity: 0.72;
+}
+
+.hero-float {
+  position: absolute;
+  right: -40px;
+  display: inline-flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 18px 24px;
+  border-radius: 24px;
+  background: rgba(255, 255, 255, 0.85);
+  color: var(--ink);
+  font-size: 14px;
+  box-shadow: 0 18px 40px rgba(99, 102, 241, 0.24);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.hero-pill {
+  top: 24px;
+}
+
+.hero-availability {
+  bottom: 24px;
+}
+
+.hero-availability strong {
+  font-size: 20px;
+  letter-spacing: normal;
+  text-transform: none;
+}
+
+.section {
+  margin-top: 120px;
+  display: flex;
+  flex-direction: column;
+  gap: 48px;
+}
+
+.section-heading {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  max-width: 640px;
+}
+
+.section-heading h2 {
+  font-size: clamp(36px, 5vw, 64px);
+  line-height: 1.05;
+  text-transform: uppercase;
+}
+
+.about-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr);
+  gap: 48px;
+  align-items: center;
+}
+
+.about-layout img {
+  border-radius: 36px;
+  box-shadow: 0 30px 80px rgba(99, 102, 241, 0.18);
+}
+
+.about-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.about-copy p {
+  font-size: 18px;
+  color: var(--muted);
+}
+
+.about-highlights {
+  display: grid;
+  gap: 20px;
+  list-style: none;
+}
+
+.about-highlights li {
+  padding: 20px 24px;
+  border-radius: 24px;
+  background: rgba(255, 255, 255, 0.78);
+  box-shadow: 0 20px 60px rgba(15, 23, 42, 0.08);
+  display: grid;
+  gap: 8px;
+}
+
+.highlight-title {
+  font-size: 14px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+.highlight-description {
+  color: var(--muted);
+}
+
+.services .section-heading {
+  max-width: 540px;
+}
+
+.service-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 28px;
+}
+
+.service-card {
+  padding: 32px;
+  border-radius: 28px;
+  background: rgba(255, 255, 255, 0.85);
+  box-shadow: 0 28px 80px rgba(15, 23, 42, 0.1);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  border: 1px solid rgba(109, 40, 217, 0.08);
+}
+
+.service-card h3 {
+  font-size: 20px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.service-card p {
+  color: var(--muted);
+}
+
+.learn-more {
+  margin-top: auto;
+  font-size: 13px;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.case-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 32px;
+}
+
+.case-card {
+  border-radius: 32px;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 32px 90px rgba(15, 23, 42, 0.12);
+  display: flex;
+  flex-direction: column;
+}
+
+.case-media {
+  width: 100%;
+  height: 220px;
+  object-fit: cover;
+}
+
+.case-body {
+  padding: 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.case-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.case-title {
+  font-size: 18px;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+}
+
+.case-subtitle {
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.tag-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.tag {
+  padding: 6px 14px;
+  border-radius: 999px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-size: 12px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 28px;
+}
+
+.gallery-card {
+  border-radius: 28px;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.85);
+  box-shadow: 0 26px 72px rgba(15, 23, 42, 0.12);
+  display: flex;
+  flex-direction: column;
+}
+
+.gallery-card img {
+  height: 220px;
+  object-fit: cover;
+}
+
+.gallery-card figcaption {
+  padding: 20px 24px;
+  font-size: 14px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.contact {
+  margin-top: 160px;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  align-items: center;
+}
+
+.contact-card {
+  padding: 64px;
+  border-radius: 40px;
+  background: linear-gradient(135deg, #1d4ed8, #7c3aed);
+  color: white;
+  box-shadow: 0 32px 100px rgba(79, 70, 229, 0.35);
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  max-width: 720px;
+}
+
+.contact-card p {
+  max-width: 520px;
+  margin: 0 auto;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.contact-card .eyebrow {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.contact-actions {
+  display: flex;
+  justify-content: center;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.contact .btn.ghost {
+  color: white;
+  border-color: rgba(255, 255, 255, 0.4);
+}
+
+.footer-note {
+  font-size: 13px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+@media (max-width: 1080px) {
+  .hero {
+    padding: 72px 48px 0 48px;
+  }
+
+  .hero-float {
+    right: -8px;
+  }
+}
+
+@media (max-width: 960px) {
+  .header-surface {
+    border-radius: 32px;
+  }
+
+  .hero {
+    grid-template-columns: 1fr;
+    padding: 60px 40px 0 40px;
+  }
+
+  .hero-visual {
+    order: -1;
+  }
+
+  .hero-float {
+    position: static;
+    flex-direction: row;
+    justify-content: space-between;
+    width: 100%;
+    margin-top: 24px;
+  }
+
+  .hero-availability {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .hero-stats {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .about-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .service-grid,
+  .case-grid,
+  .gallery-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 640px) {
+  .nav {
+    flex-direction: column;
+    gap: 16px;
+    padding: 24px 24px 0;
+  }
+
+  .nav-links {
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  .hero {
+    padding: 48px 24px 0;
+    gap: 40px;
+  }
+
+  .hero-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .hero-stats {
+    grid-template-columns: 1fr;
+  }
+
+  .service-grid,
+  .case-grid,
+  .gallery-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .contact-card {
+    padding: 48px 32px;
+  }
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  esbuild: {
+    jsxInject: "import React from 'react';",
+  },
+});


### PR DESCRIPTION
## Summary
- redesign the landing page structure with a richer hero, navigation, and content sections matching the portfolio aesthetic
- expand content modules for about, services, projects, and gallery with reusable data-driven cards
- overhaul the styling system with gradients, glassmorphism, and responsive layouts to mirror the reference composition

## Testing
- npm install *(fails: 403 Forbidden when downloading dependencies in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3eab3cbd08322be5e0a4445c77b4c